### PR TITLE
BREAKING chore(pkg): drop support for Node 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v1
         with:
-          node-version: 8
+          node-version: 10
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
       - name: Browser Tests

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "qunit-dom": "^0.9.0"
   },
   "engines": {
-    "node": "8.* || >= 10.*"
+    "node": ">= 10.*"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
EOL was reached and some dependencies cannot be merged as they require Node 10 at minimum now.
